### PR TITLE
Ability ID changes

### DIFF
--- a/Gen 9/scarlet-violet/Data/Studio/abilities/embody_aspect.json
+++ b/Gen 9/scarlet-violet/Data/Studio/abilities/embody_aspect.json
@@ -1,6 +1,6 @@
 {
   "klass": "Ability",
-  "id": 301,
+  "id": 303,
   "dbSymbol": "embody_aspect",
-  "textId": 301
+  "textId": 303
 }

--- a/Gen 9/scarlet-violet/Data/Studio/abilities/hospitality.json
+++ b/Gen 9/scarlet-violet/Data/Studio/abilities/hospitality.json
@@ -1,6 +1,6 @@
 {
   "klass": "Ability",
-  "id": 299,
+  "id": 301,
   "dbSymbol": "hospitality",
-  "textId": 299
+  "textId": 301
 }

--- a/Gen 9/scarlet-violet/Data/Studio/abilities/mind_s_eye.json
+++ b/Gen 9/scarlet-violet/Data/Studio/abilities/mind_s_eye.json
@@ -1,6 +1,6 @@
 {
   "klass": "Ability",
-  "id": 300,
+  "id": 299,
   "dbSymbol": "mind_s_eye",
-  "textId": 300
+  "textId": 299
 }

--- a/Gen 9/scarlet-violet/Data/Studio/abilities/supersweet_syrup.json
+++ b/Gen 9/scarlet-violet/Data/Studio/abilities/supersweet_syrup.json
@@ -1,6 +1,6 @@
 {
   "klass": "Ability",
-  "id": 306,
+  "id": 300,
   "dbSymbol": "supersweet_syrup",
-  "textId": 306
+  "textId": 300
 }

--- a/Gen 9/scarlet-violet/Data/Studio/abilities/toxic_chain.json
+++ b/Gen 9/scarlet-violet/Data/Studio/abilities/toxic_chain.json
@@ -1,6 +1,6 @@
 {
   "klass": "Ability",
-  "id": 305,
+  "id": 302,
   "dbSymbol": "toxic_chain",
-  "textId": 305
+  "textId": 302
 }


### PR DESCRIPTION
Fixes
Ability: ToxicChain does not appear in Pokemon Studio. Fixed
Ability: MindsEye ,EmbodyAspect, SupersweetSyrup and Hospitality now point to the correct name and text ID
