### PR TITLE
Basculin catch rate commit

### DIFF
--- a/Gen 9/scarlet-violet/Data/Studio/pokemon/basculin.json
+++ b/Gen 9/scarlet-violet/Data/Studio/pokemon/basculin.json
@@ -29,7 +29,7 @@
       "experienceType": 1,
       "baseExperience": 161,
       "baseLoyalty": 50,
-      "catchRate": 25,
+      "catchRate": 190,
       "femaleRate": 50,
       "breedGroups": [
         12,
@@ -340,7 +340,7 @@
       "experienceType": 1,
       "baseExperience": 161,
       "baseLoyalty": 50,
-      "catchRate": 25,
+      "catchRate": 190,
       "femaleRate": 50,
       "breedGroups": [
         12,
@@ -680,7 +680,7 @@
       "experienceType": 1,
       "baseExperience": 161,
       "baseLoyalty": 50,
-      "catchRate": 25,
+      "catchRate": 190,
       "femaleRate": 50,
       "breedGroups": [
         12,


### PR DESCRIPTION
Basculin had its catch rate increased from 25 to 190 with version update 2.0.1 of Scarlet and Violet. This pull should change the catch rate of all 3 basculin forms to 190.