### PR TITLE
Update escape_rope.json

### DIFF
--- a/Gen 8/sword-shield/Data/Studio/items/escape_rope.json
+++ b/Gen 8/sword-shield/Data/Studio/items/escape_rope.json
@@ -3,13 +3,13 @@
   "id": 78,
   "dbSymbol": "escape_rope",
   "icon": "078",
-  "price": 550,
-  "socket": 1,
+  "price": 0,
+  "socket": 5,
   "position": 0,
   "isBattleUsable": false,
   "isMapUsable": true,
-  "isLimited": true,
-  "isHoldable": true,
-  "flingPower": 30,
+  "isLimited": false,
+  "isHoldable": false,
+  "flingPower": 0,
   "eventId": 13
 }


### PR DESCRIPTION
Starting in Pokémon Sword and Shield, Escape Rope is a key item. Escape Rope isn't present in Scarlet and Violet but I believe in those cases for all absent moves and items, the prior implementation is used.