### PR TITLE
Fix forests curse wrong dbsymbol in pokemon moves

### DIFF
--- a/Gen 6/omega-ruby-alpha-sapphire/Data/Studio/pokemon/phantump.json
+++ b/Gen 6/omega-ruby-alpha-sapphire/Data/Studio/pokemon/phantump.json
@@ -121,7 +121,7 @@
           "level": 31
         },
         {
-          "move": "forests_curse",
+          "move": "forest_s_curse",
           "klass": "LevelLearnableMove",
           "level": 35
         },

--- a/Gen 6/omega-ruby-alpha-sapphire/Data/Studio/pokemon/trevenant.json
+++ b/Gen 6/omega-ruby-alpha-sapphire/Data/Studio/pokemon/trevenant.json
@@ -115,7 +115,7 @@
           "level": 31
         },
         {
-          "move": "forests_curse",
+          "move": "forest_s_curse",
           "klass": "LevelLearnableMove",
           "level": 35
         },

--- a/Gen 6/x-y/Data/Studio/pokemon/phantump.json
+++ b/Gen 6/x-y/Data/Studio/pokemon/phantump.json
@@ -121,7 +121,7 @@
           "level": 31
         },
         {
-          "move": "forests_curse",
+          "move": "forest_s_curse",
           "klass": "LevelLearnableMove",
           "level": 35
         },

--- a/Gen 6/x-y/Data/Studio/pokemon/trevenant.json
+++ b/Gen 6/x-y/Data/Studio/pokemon/trevenant.json
@@ -115,7 +115,7 @@
           "level": 31
         },
         {
-          "move": "forests_curse",
+          "move": "forest_s_curse",
           "klass": "LevelLearnableMove",
           "level": 35
         },

--- a/Gen 7/sun-moon/Data/Studio/pokemon/phantump.json
+++ b/Gen 7/sun-moon/Data/Studio/pokemon/phantump.json
@@ -121,7 +121,7 @@
           "level": 31
         },
         {
-          "move": "forests_curse",
+          "move": "forest_s_curse",
           "klass": "LevelLearnableMove",
           "level": 35
         },

--- a/Gen 7/sun-moon/Data/Studio/pokemon/trevenant.json
+++ b/Gen 7/sun-moon/Data/Studio/pokemon/trevenant.json
@@ -130,7 +130,7 @@
           "level": 31
         },
         {
-          "move": "forests_curse",
+          "move": "forest_s_curse",
           "klass": "LevelLearnableMove",
           "level": 35
         },

--- a/Gen 7/ultra-sun-ultra-moon/Data/Studio/pokemon/phantump.json
+++ b/Gen 7/ultra-sun-ultra-moon/Data/Studio/pokemon/phantump.json
@@ -121,7 +121,7 @@
           "level": 31
         },
         {
-          "move": "forests_curse",
+          "move": "forest_s_curse",
           "klass": "LevelLearnableMove",
           "level": 35
         },

--- a/Gen 7/ultra-sun-ultra-moon/Data/Studio/pokemon/trevenant.json
+++ b/Gen 7/ultra-sun-ultra-moon/Data/Studio/pokemon/trevenant.json
@@ -130,7 +130,7 @@
           "level": 31
         },
         {
-          "move": "forests_curse",
+          "move": "forest_s_curse",
           "klass": "LevelLearnableMove",
           "level": 35
         },

--- a/Gen 8/sword-shield/Data/Studio/pokemon/phantump.json
+++ b/Gen 8/sword-shield/Data/Studio/pokemon/phantump.json
@@ -146,7 +146,7 @@
           "level": 48
         },
         {
-          "move": "forests_curse",
+          "move": "forest_s_curse",
           "klass": "LevelLearnableMove",
           "level": 52
         },

--- a/Gen 8/sword-shield/Data/Studio/pokemon/trevenant.json
+++ b/Gen 8/sword-shield/Data/Studio/pokemon/trevenant.json
@@ -140,7 +140,7 @@
           "level": 48
         },
         {
-          "move": "forests_curse",
+          "move": "forest_s_curse",
           "klass": "LevelLearnableMove",
           "level": 52
         },

--- a/Gen 9/scarlet-violet/Data/Studio/pokemon/phantump.json
+++ b/Gen 9/scarlet-violet/Data/Studio/pokemon/phantump.json
@@ -146,7 +146,7 @@
           "level": 48
         },
         {
-          "move": "forests_curse",
+          "move": "forest_s_curse",
           "klass": "LevelLearnableMove",
           "level": 52
         },

--- a/Gen 9/scarlet-violet/Data/Studio/pokemon/trevenant.json
+++ b/Gen 9/scarlet-violet/Data/Studio/pokemon/trevenant.json
@@ -135,7 +135,7 @@
           "level": 48
         },
         {
-          "move": "forests_curse",
+          "move": "forest_s_curse",
           "klass": "LevelLearnableMove",
           "level": 52
         },


### PR DESCRIPTION
Fixed Phantump and Trevenant moves Forests curse which had the wrong dbsymbol: 'forests_curse' instead of 'forest_s_curse'
Fixed it for every generation containing Phantump and Trevenent which are gen 6-9