### PR TITLE
Fix formatting in 9001 csv file for Chandelurites entry

### DIFF
--- a/Gen 9/Legends Z-A/Data/Text/Dialogs/9001.csv
+++ b/Gen 9/Legends Z-A/Data/Text/Dialogs/9001.csv
@@ -841,7 +841,7 @@ Scolipites,Brutapodites,Scolipites,Scolipites,Scolipites,Scolipites,Scolipites
 Scraftinites,Baggaïdites,Scraftinites,Scraftinites,Scraftinites,Scraftinites,Scraftinites
 Eelektrossites,Ohmassacrites,Eelektrossites,Eelektrossites,Eelektrossites,Eelektrossites,Eelektrossites
 Forage Bags,Sacs Ingrédients,Portaingredienti,Zutatenbeutel,Zurrones,재료주머니,ざいりょうぶくろ
-Chandelurites,Lugulabrites,Chandelurites,Chandelurites,Chandelurites,Chandelurites,Chandelurites,
+Chandelurites,Lugulabrites,Chandelurites,Chandelurites,Chandelurites,Chandelurites,Chandelurites
 Professor’s Masks,Masques du Prof,Maschere Prof.,Masken des Profs,Máscaras Profesor,박사의복면,はかせのふくめん
 Festival Tickets,Festickets,Festicket,Festival-Tickets,Festicupones,페스티켓,フェスチケット
 Sparkling Stones,Gemmes Lumière,Pietre lucenti,Glitzersteine,Piedras Brillantes,빛나는돌,かがやくいし


### PR DESCRIPTION
This PR fixes the 9001.csv file of Gen 9 / Z-A data pack to prevent PSDK crashes.

### Before fix
<img width="1101" height="131" alt="image" src="https://github.com/user-attachments/assets/ff6ec8d3-9e87-412b-814e-2074014c8982" />

### After fix
<img width="1026" height="413" alt="image" src="https://github.com/user-attachments/assets/06072c2e-e0b2-44e4-91ac-2b3ea1e28a6c" />
