### PR TITLE
Clean up unused effectChance on Triple Arrows

### DIFF
--- a/Gen 9/Legends Z-A/Data/Studio/moves/triple_arrows.json
+++ b/Gen 9/Legends Z-A/Data/Studio/moves/triple_arrows.json
@@ -48,7 +48,7 @@
       "luckRate": 30
     }
   ],
-  "effectChance": 50,
+  "effectChance": 0,
   "condition": "cool",
   "appeal": 4,
   "jam": 0,

--- a/Gen 9/scarlet-violet/Data/Studio/moves/triple_arrows.json
+++ b/Gen 9/scarlet-violet/Data/Studio/moves/triple_arrows.json
@@ -48,7 +48,7 @@
       "luckRate": 30
     }
   ],
-  "effectChance": 50,
+  "effectChance": 0,
   "condition": "cool",
   "appeal": 4,
   "jam": 0,


### PR DESCRIPTION
## Summary

- Set `effectChance` to `0` on Triple Arrows in both Gen 9 packs (scarlet-violet and Legends Z-A)
- The field is now unused since Triple Arrows uses a dedicated battle engine class with independent status/stats rolls (see related MR)
- `isEffectChance: false` was already set — this aligns the value for consistency

## Related

- pokemonsdk MR: https://gitlab.com/pokemonsdk/pokemonsdk/-/merge_requests/1795