### PR TITLE
Point Clear Smog at the new s_clear_smog function code

### DIFF
--- a/Gen 5/black-2-white-2/Data/Studio/moves/clear_smog.json
+++ b/Gen 5/black-2-white-2/Data/Studio/moves/clear_smog.json
@@ -3,7 +3,7 @@
   "id": 499,
   "dbSymbol": "clear_smog",
   "mapUse": 0,
-  "battleEngineMethod": "s_haze",
+  "battleEngineMethod": "s_clear_smog",
   "type": "poison",
   "power": 50,
   "accuracy": 0,

--- a/Gen 5/black-white/Data/Studio/moves/clear_smog.json
+++ b/Gen 5/black-white/Data/Studio/moves/clear_smog.json
@@ -3,7 +3,7 @@
   "id": 499,
   "dbSymbol": "clear_smog",
   "mapUse": 0,
-  "battleEngineMethod": "s_haze",
+  "battleEngineMethod": "s_clear_smog",
   "type": "poison",
   "power": 50,
   "accuracy": 0,

--- a/Gen 6/omega-ruby-alpha-sapphire/Data/Studio/moves/clear_smog.json
+++ b/Gen 6/omega-ruby-alpha-sapphire/Data/Studio/moves/clear_smog.json
@@ -3,7 +3,7 @@
   "id": 499,
   "dbSymbol": "clear_smog",
   "mapUse": 0,
-  "battleEngineMethod": "s_haze",
+  "battleEngineMethod": "s_clear_smog",
   "type": "poison",
   "power": 50,
   "accuracy": 0,

--- a/Gen 6/x-y/Data/Studio/moves/clear_smog.json
+++ b/Gen 6/x-y/Data/Studio/moves/clear_smog.json
@@ -3,7 +3,7 @@
   "id": 499,
   "dbSymbol": "clear_smog",
   "mapUse": 0,
-  "battleEngineMethod": "s_haze",
+  "battleEngineMethod": "s_clear_smog",
   "type": "poison",
   "power": 50,
   "accuracy": 0,

--- a/Gen 7/sun-moon/Data/Studio/moves/clear_smog.json
+++ b/Gen 7/sun-moon/Data/Studio/moves/clear_smog.json
@@ -3,7 +3,7 @@
   "id": 499,
   "dbSymbol": "clear_smog",
   "mapUse": 0,
-  "battleEngineMethod": "s_haze",
+  "battleEngineMethod": "s_clear_smog",
   "type": "poison",
   "power": 50,
   "accuracy": 0,

--- a/Gen 7/ultra-sun-ultra-moon/Data/Studio/moves/clear_smog.json
+++ b/Gen 7/ultra-sun-ultra-moon/Data/Studio/moves/clear_smog.json
@@ -3,7 +3,7 @@
   "id": 499,
   "dbSymbol": "clear_smog",
   "mapUse": 0,
-  "battleEngineMethod": "s_haze",
+  "battleEngineMethod": "s_clear_smog",
   "type": "poison",
   "power": 50,
   "accuracy": 0,

--- a/Gen 8/sword-shield/Data/Studio/moves/clear_smog.json
+++ b/Gen 8/sword-shield/Data/Studio/moves/clear_smog.json
@@ -3,7 +3,7 @@
   "id": 499,
   "dbSymbol": "clear_smog",
   "mapUse": 0,
-  "battleEngineMethod": "s_haze",
+  "battleEngineMethod": "s_clear_smog",
   "type": "poison",
   "power": 50,
   "accuracy": 0,

--- a/Gen 9/Legends Z-A/Data/Studio/moves/clear_smog.json
+++ b/Gen 9/Legends Z-A/Data/Studio/moves/clear_smog.json
@@ -3,7 +3,7 @@
   "id": 499,
   "dbSymbol": "clear_smog",
   "mapUse": 0,
-  "battleEngineMethod": "s_haze",
+  "battleEngineMethod": "s_clear_smog",
   "type": "poison",
   "power": 50,
   "accuracy": 0,

--- a/Gen 9/scarlet-violet/Data/Studio/moves/clear_smog.json
+++ b/Gen 9/scarlet-violet/Data/Studio/moves/clear_smog.json
@@ -3,7 +3,7 @@
   "id": 499,
   "dbSymbol": "clear_smog",
   "mapUse": 0,
-  "battleEngineMethod": "s_haze",
+  "battleEngineMethod": "s_clear_smog",
   "type": "poison",
   "power": 50,
   "accuracy": 0,


### PR DESCRIPTION
Point the `clear_smog` move at the new `s_clear_smog` function code.

Clear Smog was mapped to `s_haze`, which no longer deals damage after the engine move-hierarchy correction, so Clear Smog silently dealt 0 damage. The dedicated `s_clear_smog` function code restores its damage while keeping the target's stat-stage reset.

Applies to every generation pack where Clear Smog exists (Gen 5 to Gen 9, 9 files).

Engine MR (must be merged together): https://gitlab.com/pokemonsdk/pokemonsdk/-/merge_requests/1844
