### PR TITLE
Add necrozma fusion items event ids and additionnal fixes

### DIFF
--- a/Gen 5/black-2-white-2/Data/Studio/moves/secret_sword.json
+++ b/Gen 5/black-2-white-2/Data/Studio/moves/secret_sword.json
@@ -3,7 +3,7 @@
   "id": 548,
   "dbSymbol": "secret_sword",
   "mapUse": 0,
-  "battleEngineMethod": "s_basic",
+  "battleEngineMethod": "s_psyshock",
   "type": "fighting",
   "power": 85,
   "accuracy": 100,

--- a/Gen 5/black-white/Data/Studio/moves/secret_sword.json
+++ b/Gen 5/black-white/Data/Studio/moves/secret_sword.json
@@ -3,7 +3,7 @@
   "id": 548,
   "dbSymbol": "secret_sword",
   "mapUse": 0,
-  "battleEngineMethod": "s_basic",
+  "battleEngineMethod": "s_psyshock",
   "type": "fighting",
   "power": 85,
   "accuracy": 100,

--- a/Gen 6/omega-ruby-alpha-sapphire/Data/Studio/moves/secret_sword.json
+++ b/Gen 6/omega-ruby-alpha-sapphire/Data/Studio/moves/secret_sword.json
@@ -3,7 +3,7 @@
   "id": 548,
   "dbSymbol": "secret_sword",
   "mapUse": 0,
-  "battleEngineMethod": "s_basic",
+  "battleEngineMethod": "s_psyshock",
   "type": "fighting",
   "power": 85,
   "accuracy": 100,

--- a/Gen 6/x-y/Data/Studio/moves/secret_sword.json
+++ b/Gen 6/x-y/Data/Studio/moves/secret_sword.json
@@ -3,7 +3,7 @@
   "id": 548,
   "dbSymbol": "secret_sword",
   "mapUse": 0,
-  "battleEngineMethod": "s_basic",
+  "battleEngineMethod": "s_psyshock",
   "type": "fighting",
   "power": 85,
   "accuracy": 100,

--- a/Gen 7/sun-moon/Data/Studio/moves/secret_sword.json
+++ b/Gen 7/sun-moon/Data/Studio/moves/secret_sword.json
@@ -3,7 +3,7 @@
   "id": 548,
   "dbSymbol": "secret_sword",
   "mapUse": 0,
-  "battleEngineMethod": "s_basic",
+  "battleEngineMethod": "s_psyshock",
   "type": "fighting",
   "power": 85,
   "accuracy": 100,

--- a/Gen 7/ultra-sun-ultra-moon/Data/Studio/items/n_lunarizer.json
+++ b/Gen 7/ultra-sun-ultra-moon/Data/Studio/items/n_lunarizer.json
@@ -6,11 +6,12 @@
   "socket": 5,
   "position": 0,
   "isBattleUsable": false,
-  "isMapUsable": false,
+  "isMapUsable": true,
   "isLimited": false,
   "isHoldable": false,
   "isAllowingMega": false,
   "flingPower": 0,
-  "klass": "Item",
+  "klass": "EventItem",
+  "eventId": 42,
   "isBerry": false
 }

--- a/Gen 7/ultra-sun-ultra-moon/Data/Studio/items/n_lunarizer2.json
+++ b/Gen 7/ultra-sun-ultra-moon/Data/Studio/items/n_lunarizer2.json
@@ -6,11 +6,12 @@
   "socket": 5,
   "position": 0,
   "isBattleUsable": false,
-  "isMapUsable": false,
+  "isMapUsable": true,
   "isLimited": false,
+  "eventId": 43,
   "isHoldable": false,
   "isAllowingMega": false,
   "flingPower": 0,
-  "klass": "Item",
+  "klass": "EventItem",
   "isBerry": false
 }

--- a/Gen 7/ultra-sun-ultra-moon/Data/Studio/items/n_solarizer.json
+++ b/Gen 7/ultra-sun-ultra-moon/Data/Studio/items/n_solarizer.json
@@ -6,11 +6,12 @@
   "socket": 5,
   "position": 0,
   "isBattleUsable": false,
-  "isMapUsable": false,
+  "isMapUsable": true,
+  "eventId": 40,
   "isLimited": false,
   "isHoldable": false,
   "isAllowingMega": false,
   "flingPower": 0,
-  "klass": "Item",
+  "klass": "EventItem",
   "isBerry": false
 }

--- a/Gen 7/ultra-sun-ultra-moon/Data/Studio/items/n_solarizer2.json
+++ b/Gen 7/ultra-sun-ultra-moon/Data/Studio/items/n_solarizer2.json
@@ -6,11 +6,12 @@
   "socket": 5,
   "position": 0,
   "isBattleUsable": false,
-  "isMapUsable": false,
+  "eventId": 41,
+  "isMapUsable": true,
   "isLimited": false,
   "isHoldable": false,
   "isAllowingMega": false,
   "flingPower": 0,
-  "klass": "Item",
+  "klass": "EventItem",
   "isBerry": false
 }

--- a/Gen 7/ultra-sun-ultra-moon/Data/Studio/moves/secret_sword.json
+++ b/Gen 7/ultra-sun-ultra-moon/Data/Studio/moves/secret_sword.json
@@ -3,7 +3,7 @@
   "id": 548,
   "dbSymbol": "secret_sword",
   "mapUse": 0,
-  "battleEngineMethod": "s_basic",
+  "battleEngineMethod": "s_psyshock",
   "type": "fighting",
   "power": 85,
   "accuracy": 100,

--- a/Gen 8/sword-shield/Data/Studio/items/n_lunarizer.json
+++ b/Gen 8/sword-shield/Data/Studio/items/n_lunarizer.json
@@ -6,11 +6,12 @@
   "socket": 5,
   "position": 0,
   "isBattleUsable": false,
-  "isMapUsable": false,
+  "isMapUsable": true,
   "isLimited": false,
+  "eventId": 42,
   "isHoldable": false,
   "isAllowingMega": false,
   "flingPower": 0,
-  "klass": "Item",
+  "klass": "EventItem",
   "isBerry": false
 }

--- a/Gen 8/sword-shield/Data/Studio/items/n_lunarizer2.json
+++ b/Gen 8/sword-shield/Data/Studio/items/n_lunarizer2.json
@@ -6,11 +6,12 @@
   "socket": 5,
   "position": 0,
   "isBattleUsable": false,
-  "isMapUsable": false,
+  "eventId": 43,
+  "isMapUsable": true,
   "isLimited": false,
   "isHoldable": false,
   "isAllowingMega": false,
   "flingPower": 0,
-  "klass": "Item",
+  "klass": "EventItem",
   "isBerry": false
 }

--- a/Gen 8/sword-shield/Data/Studio/items/n_solarizer.json
+++ b/Gen 8/sword-shield/Data/Studio/items/n_solarizer.json
@@ -6,11 +6,12 @@
   "socket": 5,
   "position": 0,
   "isBattleUsable": false,
-  "isMapUsable": false,
+  "eventId": 40,
+  "isMapUsable": true,
   "isLimited": false,
   "isHoldable": false,
   "isAllowingMega": false,
   "flingPower": 0,
-  "klass": "Item",
+  "klass": "EventItem",
   "isBerry": false
 }

--- a/Gen 8/sword-shield/Data/Studio/items/n_solarizer2.json
+++ b/Gen 8/sword-shield/Data/Studio/items/n_solarizer2.json
@@ -6,11 +6,12 @@
   "socket": 5,
   "position": 0,
   "isBattleUsable": false,
-  "isMapUsable": false,
+  "eventId": 41,
+  "isMapUsable": true,
   "isLimited": false,
   "isHoldable": false,
   "isAllowingMega": false,
   "flingPower": 0,
-  "klass": "Item",
+  "klass": "EventItem",
   "isBerry": false
 }

--- a/Gen 8/sword-shield/Data/Studio/moves/secret_sword.json
+++ b/Gen 8/sword-shield/Data/Studio/moves/secret_sword.json
@@ -3,7 +3,7 @@
   "id": 548,
   "dbSymbol": "secret_sword",
   "mapUse": 0,
-  "battleEngineMethod": "s_basic",
+  "battleEngineMethod": "s_psyshock",
   "type": "fighting",
   "power": 85,
   "accuracy": 100,

--- a/Gen 9/Legends Z-A/Data/Studio/items/n_lunarizer.json
+++ b/Gen 9/Legends Z-A/Data/Studio/items/n_lunarizer.json
@@ -6,11 +6,12 @@
   "socket": 5,
   "position": 0,
   "isBattleUsable": false,
-  "isMapUsable": false,
+  "isMapUsable": true,
+  "eventId": 42,
   "isLimited": false,
   "isHoldable": false,
   "isAllowingMega": false,
   "flingPower": 0,
-  "klass": "Item",
+  "klass": "EventItem",
   "isBerry": false
 }

--- a/Gen 9/Legends Z-A/Data/Studio/items/n_lunarizer2.json
+++ b/Gen 9/Legends Z-A/Data/Studio/items/n_lunarizer2.json
@@ -6,11 +6,12 @@
   "socket": 5,
   "position": 0,
   "isBattleUsable": false,
-  "isMapUsable": false,
+  "isMapUsable": true,
+  "eventId": 43,
   "isLimited": false,
   "isHoldable": false,
   "isAllowingMega": false,
   "flingPower": 0,
-  "klass": "Item",
+  "klass": "EventItem",
   "isBerry": false
 }

--- a/Gen 9/Legends Z-A/Data/Studio/items/n_solarizer.json
+++ b/Gen 9/Legends Z-A/Data/Studio/items/n_solarizer.json
@@ -6,11 +6,12 @@
   "socket": 5,
   "position": 0,
   "isBattleUsable": false,
-  "isMapUsable": false,
+  "eventId": 40,
+  "isMapUsable": true,
   "isLimited": false,
   "isHoldable": false,
   "isAllowingMega": false,
   "flingPower": 0,
-  "klass": "Item",
+  "klass": "EventItem",
   "isBerry": false
 }

--- a/Gen 9/Legends Z-A/Data/Studio/items/n_solarizer2.json
+++ b/Gen 9/Legends Z-A/Data/Studio/items/n_solarizer2.json
@@ -6,11 +6,12 @@
   "socket": 5,
   "position": 0,
   "isBattleUsable": false,
-  "isMapUsable": false,
+  "eventId": 41,
+  "isMapUsable": true,
   "isLimited": false,
   "isHoldable": false,
   "isAllowingMega": false,
   "flingPower": 0,
-  "klass": "Item",
+  "klass": "EventItem",
   "isBerry": false
 }

--- a/Gen 9/Legends Z-A/Data/Studio/moves/secret_sword.json
+++ b/Gen 9/Legends Z-A/Data/Studio/moves/secret_sword.json
@@ -3,7 +3,7 @@
   "id": 548,
   "dbSymbol": "secret_sword",
   "mapUse": 0,
-  "battleEngineMethod": "s_basic",
+  "battleEngineMethod": "s_psyshock",
   "type": "fighting",
   "power": 85,
   "accuracy": 100,

--- a/Gen 9/scarlet-violet/Data/Studio/items/n_lunarizer.json
+++ b/Gen 9/scarlet-violet/Data/Studio/items/n_lunarizer.json
@@ -6,11 +6,12 @@
   "socket": 5,
   "position": 0,
   "isBattleUsable": false,
-  "isMapUsable": false,
   "isLimited": false,
   "isHoldable": false,
   "isAllowingMega": false,
   "flingPower": 0,
-  "klass": "Item",
-  "isBerry": false
+  "isBerry": false,
+  "klass": "EventItem",
+  "isMapUsable": true,
+  "eventId": 42
 }

--- a/Gen 9/scarlet-violet/Data/Studio/items/n_lunarizer2.json
+++ b/Gen 9/scarlet-violet/Data/Studio/items/n_lunarizer2.json
@@ -6,11 +6,12 @@
   "socket": 5,
   "position": 0,
   "isBattleUsable": false,
-  "isMapUsable": false,
+  "isMapUsable": true,
   "isLimited": false,
   "isHoldable": false,
   "isAllowingMega": false,
   "flingPower": 0,
-  "klass": "Item",
+  "klass": "EventItem",
+  "eventId": 43,
   "isBerry": false
 }

--- a/Gen 9/scarlet-violet/Data/Studio/items/n_solarizer.json
+++ b/Gen 9/scarlet-violet/Data/Studio/items/n_solarizer.json
@@ -6,11 +6,12 @@
   "socket": 5,
   "position": 0,
   "isBattleUsable": false,
-  "isMapUsable": false,
+  "eventId": 40,
+  "isMapUsable": true,
   "isLimited": false,
   "isHoldable": false,
   "isAllowingMega": false,
   "flingPower": 0,
-  "klass": "Item",
+  "klass": "EventItem",
   "isBerry": false
 }

--- a/Gen 9/scarlet-violet/Data/Studio/items/n_solarizer2.json
+++ b/Gen 9/scarlet-violet/Data/Studio/items/n_solarizer2.json
@@ -6,11 +6,12 @@
   "socket": 5,
   "position": 0,
   "isBattleUsable": false,
-  "isMapUsable": false,
+  "eventId": 41,
+  "isMapUsable": true,
   "isLimited": false,
   "isHoldable": false,
   "isAllowingMega": false,
   "flingPower": 0,
-  "klass": "Item",
+  "klass": "EventItem",
   "isBerry": false
 }

--- a/Gen 9/scarlet-violet/Data/Studio/moves/secret_sword.json
+++ b/Gen 9/scarlet-violet/Data/Studio/moves/secret_sword.json
@@ -3,7 +3,7 @@
   "id": 548,
   "dbSymbol": "secret_sword",
   "mapUse": 0,
-  "battleEngineMethod": "s_basic",
+  "battleEngineMethod": "s_psyshock",
   "type": "fighting",
   "power": 85,
   "accuracy": 100,


### PR DESCRIPTION
This PR does the following:
- re-add the common events IDs to Necrozma fusion items
- fix Secret Sword BE method
- fix gen 8 species name text file